### PR TITLE
Add repository URL to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='slug',
         long_description=read('README'),
         packages=['slug'],
         project_urls={
-            "Source Code": "https://github.com/nanticzz/python-slug",
+            "Source Code": "https://github.com/nan-tic/python-slug",
         },
         classifiers=[
             'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(name='slug',
         description="Python module to convert str to slug",
         long_description=read('README'),
         packages=['slug'],
+        project_urls={
+            "Source Code": "https://github.com/nanticzz/python-slug",
+        },
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Environment :: Web Environment',


### PR DESCRIPTION
With this PR, the [Github repository](https://github.com/nanticzz/python-slug) can be found from the [pypi.org page](https://pypi.org/project/slug/).

I found the `project_urls` parameter in https://setuptools.readthedocs.io/en/latest/setuptools.html#basic-use example.